### PR TITLE
Fixes sendClientComand for crowbaring cardoors

### DIFF
--- a/lua/client/Lockpicking/Crowbar/CrowbarWindow.lua
+++ b/lua/client/Lockpicking/Crowbar/CrowbarWindow.lua
@@ -114,10 +114,14 @@ end
 
 function CrowbarWindow:doUnlock()
     if self.mode == MODE_VEHICLE_DOOR then	-- ДВЕРЬ МАШИНЫ
-        self.lockpick_object:getDoor():setLocked(false);
-		self.lockpick_object:getDoor():setOpen(true);
-		self.lockpick_object:getDoor():setLockBroken(true);
+        --self.lockpick_object:getDoor():setLocked(false);
+		--self.lockpick_object:getDoor():setOpen(true);
+		--self.lockpick_object:getDoor():setLockBroken(true);
+
+        sendClientCommand(self.character, 'crowbar', 'vehicleDoor', { vehicle=self.lockpick_object:getVehicle():getId(), part=self.lockpick_object:getId() })
+
         self.character:getEmitter():playSound("UnlockDoor");
+
     elseif self.mode == MODE_WINDOW then	-- ОКНО
         self.lockpick_object:setIsLocked(false)
 

--- a/lua/server/zReBL_commands.lua
+++ b/lua/server/zReBL_commands.lua
@@ -1,0 +1,22 @@
+---THIS IS CALLED IN CLIENT
+--sendClientCommand(self.character, 'crowbar', 'vehicleDoor', { vehicle=lockpick_object:getVehicle():getId(), part=lockpick_object:getId() })
+
+---THIS GOES IN /SERVER/
+local function crowbarCommands(module, command, player, args)
+
+    if module == "crowbar" and command == "vehicleDoor" then
+        local vehicle = getVehicleById(args.vehicle)
+        if not vehicle then return end
+
+        local part = vehicle:getPartById(args.part)
+        if not part then return end
+
+        if not part:getDoor() then return end
+
+        part:getDoor():setLocked(false)
+        part:getDoor():setLockBroken(true)
+
+        vehicle:transmitPartDoor(part)
+    end
+end
+Events.OnClientCommand.Add(crowbarCommands)

--- a/lua/server/zReBL_commands.lua
+++ b/lua/server/zReBL_commands.lua
@@ -14,6 +14,7 @@ local function crowbarCommands(module, command, player, args)
         if not part:getDoor() then return end
 
         part:getDoor():setLocked(false)
+        part:getDoor():setOpen(true)
         part:getDoor():setLockBroken(true)
 
         vehicle:transmitPartDoor(part)


### PR DESCRIPTION
Turns out what I sent was wrong, in that it needed the self. in front of the lockpick_object.